### PR TITLE
Add an endgame recipe for the creative tablet

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,4 +9,8 @@ dependencies {
     runtime('com.github.GTNewHorizons:Baubles:1.0.1.14:dev') {transitive=false}
     runtime('com.github.GTNewHorizons:TinkersConstruct:1.9.0.13-GTNH:dev') {transitive=false}
     runtime('com.github.GTNewHorizons:Mantle:0.3.4:dev') {transitive=false}
+
+    compile("com.github.GTNewHorizons:Chisel:2.10.8-GTNH:dev") {transitive = false}
+    compile("com.github.GTNewHorizons:Avaritia:1.22:dev") {transitive = false}
+    
 }

--- a/src/main/java/net/fuzzycraft/botanichorizons/mod/ForgeMod.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/mod/ForgeMod.java
@@ -10,7 +10,7 @@ public class ForgeMod {
     public static final String MOD_ID = "botanichorizons";
     public static final String MOD_NAME = MOD_ID;
     public static final String VERSION = "GRADLETOKEN_VERSION";
-    public static final String DEPENDENCIES = "required-after:Baubles;required-after:Thaumcraft;required-after:Botania;required-after:gregtech;after:witchery;after:BiomesOPlenty;after:dreamcraft;required-after:TConstruct";
+    public static final String DEPENDENCIES = "required-after:Baubles;required-after:Thaumcraft;required-after:Botania;required-after:gregtech;after:witchery;after:BiomesOPlenty;after:dreamcraft;required-after:TConstruct;required-after:Avaritia";
 
     @Mod.Instance(MOD_ID)
     public static ForgeMod instance;
@@ -30,6 +30,7 @@ public class ForgeMod {
         BreweryPatches.applyPatches();
 
         GregtechPatches.applyPatches();
+        AvaritiaPatches.applyPatches();
     }
 
     @Mod.EventHandler

--- a/src/main/java/net/fuzzycraft/botanichorizons/patches/AvaritiaPatches.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/patches/AvaritiaPatches.java
@@ -1,0 +1,84 @@
+package net.fuzzycraft.botanichorizons.patches;
+
+import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
+import net.fuzzycraft.botanichorizons.util.Constants;
+import net.minecraft.item.ItemStack;
+import vazkii.botania.common.block.ModBlocks;
+import vazkii.botania.common.item.ItemManaTablet;
+import vazkii.botania.common.item.ModItems;
+import vazkii.botania.common.lib.LibOreDict;
+
+public class AvaritiaPatches {
+    public static void applyPatches() {
+        ItemStack creativeTablet = new ItemStack(ModItems.manaTablet, 1, 500000);
+        ItemManaTablet.setMana(creativeTablet, 500000);
+        ItemManaTablet.setStackCreative(creativeTablet);
+        ExtremeCraftingManager.getInstance().addExtremeShapedOreRecipe(
+                creativeTablet,
+                //"SSSSSSSSS","IIIIIIIII","iiiiiiiii","iiiiiiiii","iiiiiiiii","iiiiiiiii","iiiiiiiii","iiiiiiiii","iiiiiiiii",
+                "GSISaSISG",
+                "SMMM1MMMS",
+                "IMPD5DPMI",
+                "SMDTTTDMS",
+                "c37TiT84c",
+                "SMDTTTDMS",
+                "IMPD6DPMI",
+                "SMMM2MMMS",
+                "GSISbSISG",
+                'M', new ItemStack(ModBlocks.storage, 1, Constants.STORAGE_META_MANASTEELBLOCK),
+                'D', new ItemStack(ModBlocks.storage, 1, Constants.STORAGE_META_DIAMONDBLOCK),
+                'P', LibOreDict.MANA_PEARL,
+                'G', LibOreDict.GAIA_INGOT,
+                'S', new ItemStack(ModBlocks.shimmerrock),
+                'I', "plateInfinity",
+                'i', new ItemStack(ModItems.dice), //new ItemStack(ModBlocks.conjurationCatalyst),
+                'T', new ItemStack(ModItems.manaTablet),
+                'a', new ItemStack(ModItems.divaCharm),
+                'b', new ItemStack(ModItems.blackHoleTalisman),
+                'c', new ItemStack(ModItems.laputaShard, 1, 0),
+                '1', LibOreDict.RUNE[0],
+                '2', LibOreDict.RUNE[1],
+                '3', LibOreDict.RUNE[2],
+                '4', LibOreDict.RUNE[3],
+                '5', LibOreDict.RUNE[4],
+                '6', LibOreDict.RUNE[5],
+                '7', LibOreDict.RUNE[6],
+                '8', LibOreDict.RUNE[7]
+        );
+
+        ItemStack creativePool = new ItemStack(ModBlocks.pool, 1, Constants.POOL_META_CREATIVE);
+        ExtremeCraftingManager.getInstance().addExtremeShapedOreRecipe(
+                creativePool,
+                //"SSSSSSSSS","IIIIIIIII","iiiiiiiii","iiiiiiiii","iiiiiiiii","iiiiiiiii","iiiiiiiii","iiiiiiiii","iiiiiiiii",
+                "GSISaSISG",
+                "SMMM1MMMS",
+                "IMPD5DPMI",
+                "SMDTTTDMS",
+                "c37TiT84c",
+                "SMDTTTDMS",
+                "IMPD6DPMI",
+                "SMMM2MMMS",
+                "GSISbSISG",
+                'M', new ItemStack(ModBlocks.storage, 1, Constants.STORAGE_META_MANASTEELBLOCK),
+                'D', new ItemStack(ModBlocks.storage, 1, Constants.STORAGE_META_DIAMONDBLOCK),
+                'P', LibOreDict.MANA_PEARL,
+                'G', LibOreDict.GAIA_INGOT,
+                'S', new ItemStack(ModBlocks.shimmerrock),
+                'I', "plateInfinity",
+                'i', new ItemStack(ModItems.dice), //new ItemStack(ModBlocks.conjurationCatalyst),
+                'T', new ItemStack(ModBlocks.pool, 1, Constants.POOL_META_REGULAR_FABULOUS),
+                'a', new ItemStack(ModItems.missileRod),
+                'b', new ItemStack(ModBlocks.manaBomb),
+                'c', new ItemStack(ModItems.laputaShard, 1, 0),
+                '1', LibOreDict.RUNE[0],
+                '2', LibOreDict.RUNE[1],
+                '3', LibOreDict.RUNE[2],
+                '4', LibOreDict.RUNE[3],
+                '5', LibOreDict.RUNE[4],
+                '6', LibOreDict.RUNE[5],
+                '7', LibOreDict.RUNE[6],
+                '8', LibOreDict.RUNE[7]
+        );
+
+    }
+}

--- a/src/main/java/net/fuzzycraft/botanichorizons/patches/CraftingPatches.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/patches/CraftingPatches.java
@@ -21,6 +21,7 @@ import vazkii.botania.common.block.ModFluffBlocks;
 import vazkii.botania.common.block.tile.TileCraftCrate;
 import vazkii.botania.common.core.handler.ConfigHandler;
 import vazkii.botania.common.crafting.ModCraftingRecipes;
+import vazkii.botania.common.item.ItemManaTablet;
 import vazkii.botania.common.item.ItemSignalFlare;
 import vazkii.botania.common.item.ItemTwigWand;
 import vazkii.botania.common.item.ModItems;
@@ -207,15 +208,25 @@ public class CraftingPatches {
         ModCraftingRecipes.recipeManaMirror = BotaniaAPI.getLatestAddedRecipe();
 
         // Mana Tablet Recipe
-        addOreDictRecipe(new ItemStack(ModItems.manaTablet, 1, 10000),
+        addOreDictRecipe(new ItemStack(ModItems.manaTablet, 1, Constants.MANA_TABLET_MAGIC_META),
                 "SSS", "SPS", "SSS",
                 'S', LibOreDict.LIVING_ROCK,
                 'P', LibOreDict.MANA_PEARL);
-        addOreDictRecipe(new ItemStack(ModItems.manaTablet, 1, 10000),
+        addOreDictRecipe(new ItemStack(ModItems.manaTablet, 1, Constants.MANA_TABLET_MAGIC_META),
                 "SSS", "SDS", "SSS",
                 'S', LibOreDict.LIVING_ROCK,
                 'D', LibOreDict.MANA_DIAMOND);
         ModCraftingRecipes.recipesManaTablet = BotaniaAPI.getLatestAddedRecipes(2);
+
+        // Creative tablet
+        ItemStack creativeTablet = new ItemStack(ModItems.manaTablet, 1, 500000);
+        ItemManaTablet.setMana(creativeTablet, 500000);
+        ItemManaTablet.setStackCreative(creativeTablet);
+        addOreDictRecipe(creativeTablet,
+                "III", "ITI", "III",
+                'I', "plateInfinity",
+                'T', new ItemStack(ModBlocks.pool, 1, Constants.POOL_META_CREATIVE)
+        );
 
         // Mana Pump Recipe
         addOreDictRecipe(new ItemStack(ModBlocks.pump),

--- a/src/main/java/net/fuzzycraft/botanichorizons/patches/CraftingPatches.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/patches/CraftingPatches.java
@@ -113,15 +113,6 @@ public class CraftingPatches {
 
         // There is no elven mana pool in this version?
 
-        // Creative pool
-        addOreDictRecipe(new ItemStack(ModBlocks.pool, 1, Constants.POOL_META_CREATIVE),
-                "RIR", "RCR", "RRR",
-                'R', "plateInfinity",
-                'I', LibOreDict.GAIA_INGOT,
-                'C', new ItemStack(ModBlocks.pool, 1, Constants.POOL_META_REGULAR_FABULOUS)
-        );
-        ModCraftingRecipes.recipePoolFabulous = BotaniaAPI.getLatestAddedRecipe();
-
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         // regular spreader
@@ -217,16 +208,6 @@ public class CraftingPatches {
                 'S', LibOreDict.LIVING_ROCK,
                 'D', LibOreDict.MANA_DIAMOND);
         ModCraftingRecipes.recipesManaTablet = BotaniaAPI.getLatestAddedRecipes(2);
-
-        // Creative tablet
-        ItemStack creativeTablet = new ItemStack(ModItems.manaTablet, 1, 500000);
-        ItemManaTablet.setMana(creativeTablet, 500000);
-        ItemManaTablet.setStackCreative(creativeTablet);
-        addOreDictRecipe(creativeTablet,
-                "III", "ITI", "III",
-                'I', "plateInfinity",
-                'T', new ItemStack(ModBlocks.pool, 1, Constants.POOL_META_CREATIVE)
-        );
 
         // Mana Pump Recipe
         addOreDictRecipe(new ItemStack(ModBlocks.pump),

--- a/src/main/java/net/fuzzycraft/botanichorizons/util/Constants.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/util/Constants.java
@@ -106,6 +106,8 @@ public final class Constants {
     public static final int POOL_MAX_MANA_DILUTED =   10000;
     public static final int POOL_MAX_MANA_REGULAR = 1000000;
 
+    public static final int MANA_TABLET_MAGIC_META = 10000;
+
     public static ItemStack thaumcraftCrucible() {
         return new ItemStack(Block.getBlockFromName(THAUMCRAFT_METAL_DEVICE), 1, THAUMCRAFT_METAL_META_CRUCIBLE);
     }


### PR DESCRIPTION
Adds a creative tablet due to demand. It uses the already available creative pool as a dependency, so no new shortcuts are added.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10456