### PR TITLE
Add chisel support for Botania items

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,4 +9,6 @@ dependencies {
     runtime('com.github.GTNewHorizons:Baubles:1.0.1.14:dev') {transitive=false}
     runtime('com.github.GTNewHorizons:TinkersConstruct:1.9.0.13-GTNH:dev') {transitive=false}
     runtime('com.github.GTNewHorizons:Mantle:0.3.4:dev') {transitive=false}
+
+    compile("com.github.GTNewHorizons:Chisel:2.10.8-GTNH:dev") {transitive = false}
 }

--- a/src/main/java/net/fuzzycraft/botanichorizons/mod/ForgeMod.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/mod/ForgeMod.java
@@ -1,5 +1,6 @@
 package net.fuzzycraft.botanichorizons.mod;
 
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
@@ -10,7 +11,7 @@ public class ForgeMod {
     public static final String MOD_ID = "botanichorizons";
     public static final String MOD_NAME = MOD_ID;
     public static final String VERSION = "GRADLETOKEN_VERSION";
-    public static final String DEPENDENCIES = "required-after:Baubles;required-after:Thaumcraft;required-after:Botania;required-after:gregtech;after:witchery;after:BiomesOPlenty;after:dreamcraft;required-after:TConstruct";
+    public static final String DEPENDENCIES = "required-after:Baubles;required-after:Thaumcraft;required-after:Botania;required-after:gregtech;after:witchery;after:BiomesOPlenty;after:dreamcraft;required-after:TConstruct;after:chisel";
 
     @Mod.Instance(MOD_ID)
     public static ForgeMod instance;
@@ -36,5 +37,8 @@ public class ForgeMod {
     public void postInit(FMLPostInitializationEvent event) {
         ThaumcraftAspects.registerAspects();
         ThaumcraftPatches.applyPatches();
+        if (Loader.isModLoaded("chisel")) {
+            ChiselPatches.applyPatches();
+        }
     }
 }

--- a/src/main/java/net/fuzzycraft/botanichorizons/patches/ChiselPatches.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/patches/ChiselPatches.java
@@ -1,0 +1,59 @@
+package net.fuzzycraft.botanichorizons.patches;
+
+import com.cricketcraft.chisel.api.carving.CarvingUtils;
+import com.cricketcraft.chisel.api.carving.ICarvingGroup;
+import com.cricketcraft.chisel.api.carving.ICarvingRegistry;
+import vazkii.botania.common.block.ModBlocks;
+import vazkii.botania.common.block.ModFluffBlocks;
+
+import javax.annotation.Nullable;
+
+public class ChiselPatches {
+
+    public static final String GROUP_AZULEJO = "BH_Azulejo";
+    public static final String GROUP_LIVINGWOOD = "BH_Livingwood";
+    public static final String GROUP_LIVINGROCK = "BH_Livingrock";
+    public static final String GROUP_DREAMWOOD = "BH_Dreamwood";
+
+    @Nullable
+    private static ICarvingRegistry getChiselIfAvailable() {
+        return CarvingUtils.getChiselRegistry();
+    }
+
+    public static void applyPatches() {
+        ICarvingRegistry registry = getChiselIfAvailable();
+        if (registry == null) return;
+
+        // Azulejo cycling into chisel
+        ICarvingGroup azulejoGroup = new CarvingUtils.SimpleCarvingGroup(GROUP_AZULEJO);
+        registry.addGroup(azulejoGroup);
+        for (int i = 0; i < 12; i++) {
+            registry.addVariation(GROUP_AZULEJO, ModBlocks.customBrick, 4 + i, 0);
+        }
+
+        // note that some LW/LR/DW variations have special properties and can't be chiseled
+        registry.addGroup(new CarvingUtils.SimpleCarvingGroup(GROUP_LIVINGWOOD));
+        registry.addVariation(GROUP_LIVINGWOOD, ModBlocks.livingwood, 1, 0);
+        registry.addVariation(GROUP_LIVINGWOOD, ModBlocks.livingwood, 3, 0);
+        registry.addVariation(GROUP_LIVINGWOOD, ModBlocks.livingwood, 4, 0);
+
+        registry.addGroup(new CarvingUtils.SimpleCarvingGroup(GROUP_LIVINGROCK));
+        registry.addVariation(GROUP_LIVINGROCK, ModBlocks.livingrock, 1, 0);
+        registry.addVariation(GROUP_LIVINGROCK, ModBlocks.livingrock, 3, 0);
+        registry.addVariation(GROUP_LIVINGROCK, ModBlocks.livingrock, 4, 0);
+
+        registry.addGroup(new CarvingUtils.SimpleCarvingGroup(GROUP_DREAMWOOD));
+        registry.addVariation(GROUP_DREAMWOOD, ModBlocks.dreamwood, 1, 0);
+        registry.addVariation(GROUP_DREAMWOOD, ModBlocks.dreamwood, 3, 0);
+        registry.addVariation(GROUP_DREAMWOOD, ModBlocks.dreamwood, 4, 0);
+
+        // diorite etc
+        for (int i = 0; i < 4; i++) {
+            int base = 4 * i;
+            registry.addVariation("andesite", ModFluffBlocks.stone, base + 0, 0);
+            registry.addVariation("basalt", ModFluffBlocks.stone,   base + 1, 0);
+            registry.addVariation("diorite", ModFluffBlocks.stone,  base + 2, 0);
+            registry.addVariation("granite", ModFluffBlocks.stone,  base + 3, 0);
+        }
+    }
+}


### PR DESCRIPTION
- Adds pages for basic Botania planks/bricks, excluding the ones with a different price tag to avoid exploits.
- Adds a page for Azulejo blocks
- Adds Botania's diorite, andesite etc. to the existing Chisel categories

