### PR TITLE
Fix Apothecary recipes using #cropVine

### DIFF
--- a/src/main/java/net/fuzzycraft/botanichorizons/patches/ApothecaryPatches.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/patches/ApothecaryPatches.java
@@ -28,8 +28,12 @@ public class ApothecaryPatches {
         CustomBotaniaAPI.extraFlowerComponents.put(Item.getItemFromBlock(ModBlocks.mushroom), alwaysAllowHandler);
         whitelistBlockIfExists("BiomesOPlenty:flowers");
         whitelistBlockIfExists("BiomesOPlenty:flowers2");
+        whitelistBlockIfExists("BiomesOPlenty:ivy");
+        whitelistBlockIfExists("BiomesOPlenty:flowerVine");
+        whitelistBlockIfExists("Natura:Thornvines");
         CustomBotaniaAPI.extraFlowerComponents.put(Item.getItemFromBlock(Blocks.red_flower), alwaysAllowHandler);
         CustomBotaniaAPI.extraFlowerComponents.put(Item.getItemFromBlock(Blocks.yellow_flower), alwaysAllowHandler);
+        CustomBotaniaAPI.extraFlowerComponents.put(Item.getItemFromBlock(Blocks.vine), alwaysAllowHandler);
 
         // Whitelists for use with MineTweaker scripts
         whitelistItemIfExists("MagicBees:wax");


### PR DESCRIPTION
Whitelist vine types so that the apothecary will accept them and not just turn green.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11528