### PR TITLE
fix basalt chiselgroup name

### DIFF
--- a/src/main/java/net/fuzzycraft/botanichorizons/patches/ChiselPatches.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/patches/ChiselPatches.java
@@ -51,7 +51,7 @@ public class ChiselPatches {
         for (int i = 0; i < 4; i++) {
             int base = 4 * i;
             registry.addVariation("andesite", ModFluffBlocks.stone, base + 0, 0);
-            registry.addVariation("basalt", ModFluffBlocks.stone,   base + 1, 0);
+            registry.addVariation("basalts", ModFluffBlocks.stone,   base + 1, 0);
             registry.addVariation("diorite", ModFluffBlocks.stone,  base + 2, 0);
             registry.addVariation("granite", ModFluffBlocks.stone,  base + 3, 0);
         }


### PR DESCRIPTION
we want it to be in the same group as the GT/projectred/etc basalt, not separate in its own minigroup.

related to https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14488

now working:
![image](https://github.com/GTNewHorizons/Botanic-horizons/assets/40274384/86b0bc81-6bfd-4d14-b9e4-a922ef41f34f)
