### PR TITLE
Downtier Alfheim and Elementium to be mid EV instead of IV

### DIFF
--- a/src/main/java/net/fuzzycraft/botanichorizons/patches/AlfheimPatches.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/patches/AlfheimPatches.java
@@ -37,7 +37,7 @@ public class AlfheimPatches {
         ModElvenTradeRecipes.dreamwoodRecipe = BotaniaAPI.registerElvenTradeRecipe(new ItemStack(ModBlocks.dreamwood), Constants.gtTradeCasing());
 
         ModElvenTradeRecipes.elementiumRecipes = new ArrayList();
-        ModElvenTradeRecipes.elementiumRecipes.add(BotaniaAPI.registerElvenTradeRecipe(new ItemStack(ModItems.manaResource, 1, 7), "gearGtSmallTitanium"));
+        ModElvenTradeRecipes.elementiumRecipes.add(BotaniaAPI.registerElvenTradeRecipe(new ItemStack(ModItems.manaResource, 1, 7), "gearGtSmallTPVAlloy"));
 
         ModElvenTradeRecipes.pixieDustRecipe = BotaniaAPI.registerElvenTradeRecipe(new ItemStack(ModItems.manaResource, 1, 8), "craftingSunnariumPart");
 

--- a/src/main/java/net/fuzzycraft/botanichorizons/patches/AlfheimPatches.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/patches/AlfheimPatches.java
@@ -37,7 +37,7 @@ public class AlfheimPatches {
         ModElvenTradeRecipes.dreamwoodRecipe = BotaniaAPI.registerElvenTradeRecipe(new ItemStack(ModBlocks.dreamwood), Constants.gtTradeCasing());
 
         ModElvenTradeRecipes.elementiumRecipes = new ArrayList();
-        ModElvenTradeRecipes.elementiumRecipes.add(BotaniaAPI.registerElvenTradeRecipe(new ItemStack(ModItems.manaResource, 1, 7), "gearGtSmallTungstenSteel"));
+        ModElvenTradeRecipes.elementiumRecipes.add(BotaniaAPI.registerElvenTradeRecipe(new ItemStack(ModItems.manaResource, 1, 7), "gearGtSmallTitanium"));
 
         ModElvenTradeRecipes.pixieDustRecipe = BotaniaAPI.registerElvenTradeRecipe(new ItemStack(ModItems.manaResource, 1, 8), "craftingSunnariumPart");
 

--- a/src/main/java/net/fuzzycraft/botanichorizons/patches/ThaumcraftPatches.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/patches/ThaumcraftPatches.java
@@ -187,7 +187,7 @@ public class ThaumcraftPatches {
             .apply(builder -> {
                 ItemStack glimmer = new ItemStack(ModBlocks.livingwood, 1, Constants.LIVINGWOOD_META_GLIMMERING);
                 ItemStack glow = new ItemStack(Blocks.glowstone);
-                ItemStack gemIV = new ItemStack((Item) Item.itemRegistry.getObject("dreamcraft:item.EngravedEnergyChip"));
+                ItemStack gemEV = new ItemStack((Item) Item.itemRegistry.getObject("dreamcraft:item.QuantumCrystal"));
                 ItemStack construct = Constants.thaumcraftConstruct();
                 ItemStack terra = OreDict.preference("plateTerrasteel", LibOreDict.TERRA_STEEL);
 
@@ -196,7 +196,7 @@ public class ThaumcraftPatches {
                     new ItemStack(ModBlocks.alfPortal),
                     20,
                     new ItemStack(ModBlocks.alchemyCatalyst),
-                    construct, glimmer, glow, terra, construct, glimmer, gemIV, terra, construct, glimmer, glow, terra, construct, glimmer, gemIV, terra
+                    construct, glimmer, glow, terra, construct, glimmer, gemEV, terra, construct, glimmer, glow, terra, construct, glimmer, gemEV, terra
                 );
             })
             .commit();


### PR DESCRIPTION
mentioned in https://discord.com/channels/181078474394566657/939305179524792340/1389494883294904410

but really talked about here and in general chat around the same timestamp:  https://discord.com/channels/181078474394566657/603348502637969419/1389491882228187148

botania lacks much use between lv (manasteel) and post-naq (gaia) so pushing these down a tier would help give botania more attention and play. notably being in the form of the ring of far reach.

no need to merge until more discussion / counterarguments are addressed ;P