### PR TITLE
fix: Include controller block in holo projector

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,18 +1,18 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:Botania:1.12.12-GTNH:dev')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.357:dev')
+    api('com.github.GTNewHorizons:Botania:1.12.16-GTNH:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.393:dev')
     api('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
-    api("com.github.GTNewHorizons:StructureLib:1.4.12:dev")
-    api("com.github.GTNewHorizons:Avaritia:1.67:dev")
+    api("com.github.GTNewHorizons:StructureLib:1.4.15:dev")
+    api("com.github.GTNewHorizons:Avaritia:1.68:dev")
 
-    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.7.59-GTNH:dev')
+    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.7.64-GTNH:dev')
     compileOnly("com.github.GTNewHorizons:Chisel:2.16.5-GTNH:dev") {transitive = false}
 
     runtimeOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.9-GTNH:dev')
 
-    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.7.59-GTNH:dev')
+    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.7.64-GTNH:dev')
 }
 
 repositories {

--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/Multiblocks.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/Multiblocks.java
@@ -102,10 +102,10 @@ public final class Multiblocks {
 
     public static void postInit() {
         if (Mods.StructureLib.isModLoaded()) {
-            HoloProjectorSupport.registerWithStructureLib(poolInfusion, TileAdvancedCraftingPool.class);
-            HoloProjectorSupport.registerWithStructureLib(poolAlchemy, TileAdvancedAlchemyPool.class);
-            HoloProjectorSupport.registerWithStructureLib(poolConjuration, TileAdvancedConjurationPool.class);
-            HoloProjectorSupport.registerWithStructureLib(alfPortal, TileAdvancedAlfPortal.class);
+            HoloProjectorSupport.registerWithStructureLib(poolInfusion, BHBlocks.autoPoolInfusion, TileAdvancedCraftingPool.class);
+            HoloProjectorSupport.registerWithStructureLib(poolAlchemy, BHBlocks.autoPoolAlchemy, TileAdvancedAlchemyPool.class);
+            HoloProjectorSupport.registerWithStructureLib(poolConjuration, BHBlocks.autoPoolConjuration, TileAdvancedConjurationPool.class);
+            HoloProjectorSupport.registerWithStructureLib(alfPortal, BHBlocks.autoPortal, TileAdvancedAlfPortal.class);
         }
     }
 }


### PR DESCRIPTION
Between 2.7.x and 2.8.x, the implementation was changed from taking the controller block from the TE class to expecting it at (0, 0, 0) in the structure definition. This caused the blockrenderer to incorrectly deference BlockAir's null item.

This fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20445 

A separate PR for BlockRenderer would be welcome to prevent reliance on such undocumented behaviour.