### PR TITLE
Fix: Orientation bugs

### DIFF
--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/Multiblocks.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/Multiblocks.java
@@ -102,10 +102,10 @@ public final class Multiblocks {
 
     public static void postInit() {
         if (Mods.StructureLib.isModLoaded()) {
-            HoloProjectorSupport.registerWithStructureLib(poolInfusion, BHBlocks.autoPoolInfusion, TileAdvancedCraftingPool.class);
-            HoloProjectorSupport.registerWithStructureLib(poolAlchemy, BHBlocks.autoPoolAlchemy, TileAdvancedAlchemyPool.class);
-            HoloProjectorSupport.registerWithStructureLib(poolConjuration, BHBlocks.autoPoolConjuration, TileAdvancedConjurationPool.class);
-            HoloProjectorSupport.registerWithStructureLib(alfPortal, BHBlocks.autoPortal, TileAdvancedAlfPortal.class);
+            HoloProjectorSupport.registerOrientedWithStructureLib(poolInfusion, BHBlocks.autoPoolInfusion, TileAdvancedCraftingPool.class);
+            HoloProjectorSupport.registerOrientedWithStructureLib(poolAlchemy, BHBlocks.autoPoolAlchemy, TileAdvancedAlchemyPool.class);
+            HoloProjectorSupport.registerOrientedWithStructureLib(poolConjuration, BHBlocks.autoPoolConjuration, TileAdvancedConjurationPool.class);
+            HoloProjectorSupport.registerOrientedWithStructureLib(alfPortal, BHBlocks.autoPortal, TileAdvancedAlfPortal.class);
         }
     }
 }

--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/AutomationTileEntity.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/AutomationTileEntity.java
@@ -224,6 +224,7 @@ abstract public class AutomationTileEntity extends TileEntity implements IManaRe
 
     @Override
     public short getFacing() {
+        this.facing = Facing2D.fromIndex((worldObj.getBlockMetadata(xCoord, yCoord, zCoord) >> 1) & 3);
         return (short)facing.ic2index;
     }
 

--- a/src/main/java/net/fuzzycraft/botanichorizons/util/structurelib/HoloContainer.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/util/structurelib/HoloContainer.java
@@ -22,16 +22,16 @@ public class HoloContainer<T extends TileEntity> implements IMultiblockInfoConta
     }
 
     @Override
-    public void construct(ItemStack stackSize, boolean hintsOnly, T ctx, ExtendedFacing aSide) {
+    public void construct(ItemStack stackSize, boolean hintsOnly, T tileEntity, ExtendedFacing aSide) {
         structrue.buildOrHints(
-                ctx,
+                tileEntity,
                 stackSize,
                 HOLO_DEFAULT_CHANNEL,
-                ctx.getWorldObj(),
-                noSideWay(aSide),
-                ctx.xCoord,
-                ctx.yCoord,
-                ctx.zCoord,
+                tileEntity.getWorldObj(),
+                getOrientation(tileEntity, aSide),
+                tileEntity.xCoord,
+                tileEntity.yCoord,
+                tileEntity.zCoord,
                 offsetA,
                 offsetB,
                 offsetC,
@@ -39,17 +39,17 @@ public class HoloContainer<T extends TileEntity> implements IMultiblockInfoConta
     }
 
     @Override
-    public int survivalConstruct(ItemStack stackSize, int elementBudge, ISurvivalBuildEnvironment env, T ctx,
+    public int survivalConstruct(ItemStack stackSize, int elementBudge, ISurvivalBuildEnvironment env, T tileEntity,
                                  ExtendedFacing aSide) {
         return structrue.survivalBuild(
-                ctx,
+                tileEntity,
                 stackSize,
                 HOLO_DEFAULT_CHANNEL,
-                ctx.getWorldObj(),
-                noSideWay(aSide),
-                ctx.xCoord,
-                ctx.yCoord,
-                ctx.zCoord,
+                tileEntity.getWorldObj(),
+                getOrientation(tileEntity, aSide),
+                tileEntity.xCoord,
+                tileEntity.yCoord,
+                tileEntity.zCoord,
                 offsetA,
                 offsetB,
                 offsetC,
@@ -63,7 +63,7 @@ public class HoloContainer<T extends TileEntity> implements IMultiblockInfoConta
         return new String[0];
     }
 
-    private static ExtendedFacing noSideWay(ExtendedFacing aSide) {
+    public ExtendedFacing getOrientation(T tileEntity, ExtendedFacing aSide) {
         return aSide.getDirection().offsetY != 0 ? ExtendedFacing.DEFAULT : aSide.getOppositeDirection();
     }
 }

--- a/src/main/java/net/fuzzycraft/botanichorizons/util/structurelib/HoloProjectorSupport.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/util/structurelib/HoloProjectorSupport.java
@@ -4,6 +4,7 @@ import com.gtnewhorizon.structurelib.alignment.constructable.IMultiblockInfoCont
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.IStructureElement;
 import com.gtnewhorizon.structurelib.structure.StructureDefinition;
+import ic2.api.tile.IWrenchable;
 import net.fuzzycraft.botanichorizons.util.multiblock.BasicBlockCheck;
 import net.fuzzycraft.botanichorizons.util.multiblock.MetaBlockCheck;
 import net.fuzzycraft.botanichorizons.util.multiblock.MultiblockCheck;
@@ -25,7 +26,8 @@ public class HoloProjectorSupport {
 
     public static final String HOLO_DEFAULT_CHANNEL = "main";
 
-    public static <T extends TileEntity> void registerWithStructureLib(MultiblockHelper definition, Block controllerBlock, Class<T> controllerTileClass) {
+    public static <T extends TileEntity & IWrenchable> void registerOrientedWithStructureLib(MultiblockHelper definition, Block controllerBlock, Class<T> controllerTileClass) {
+
         final Map<MultiblockCheck, Character> keys = new HashMap<>();
         int xMin = definition.blocks[0].dx, xMax = definition.blocks[0].dx;
         int yMin = definition.blocks[0].dy, yMax = definition.blocks[0].dy;
@@ -85,7 +87,8 @@ public class HoloProjectorSupport {
         builder.addElement(counter, ofBlockAnyMeta(controllerBlock));
 
         IStructureDefinition<T> structure = builder.build();
-        HoloContainer<T> container = new HoloContainer<>(structure, -xMin, -yMin, -zMin);
+        HoloContainer<T> container;
+        container = new OrientedHoloContainer<>(structure, -xMin, -yMin, -zMin);
         IMultiblockInfoContainer.registerTileClass(controllerTileClass, container);
     }
 

--- a/src/main/java/net/fuzzycraft/botanichorizons/util/structurelib/OrientedHoloContainer.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/util/structurelib/OrientedHoloContainer.java
@@ -1,0 +1,19 @@
+package net.fuzzycraft.botanichorizons.util.structurelib;
+
+import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
+import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
+import ic2.api.tile.IWrenchable;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class OrientedHoloContainer<T extends TileEntity & IWrenchable> extends HoloContainer<T>{
+    public OrientedHoloContainer(IStructureDefinition<? super T> structure, int offsetA, int offsetB, int offsetC) {
+        super(structure, offsetA, offsetB, offsetC);
+    }
+
+    @Override
+    public ExtendedFacing getOrientation(T tileEntity, ExtendedFacing aSide) {
+        short ic2Facing = tileEntity.getFacing();
+        return ExtendedFacing.of(ForgeDirection.getOrientation(ic2Facing).getOpposite());
+    }
+}


### PR DESCRIPTION
This solves two minor problems hinted at during beta testing:

- The wrench orientation indicator is now correct immediately after placement without needing other interactions
- The hologram orientation now uses the block orientation instead of the player orientation for the rendering, so that placements align with the wrenched orientation and where the structure check expects to find those blocks.

Not fixed in this MR:
- StructureLib rendering the wrong block for Natura Pylons in hologram mode. This seems to be a problem in that mod specifically.