### PR TITLE
fix: Make mana fountains actually consume the mana

### DIFF
--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/SimpleAutomationTileEntity.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/SimpleAutomationTileEntity.java
@@ -1,6 +1,5 @@
 package net.fuzzycraft.botanichorizons.addons.tileentity;
 
-import cpw.mods.fml.common.FMLLog;
 import net.fuzzycraft.botanichorizons.util.InventoryHelper;
 import net.fuzzycraft.botanichorizons.util.multiblock.MultiblockHelper;
 import net.minecraft.entity.item.EntityItem;
@@ -41,6 +40,8 @@ public abstract class SimpleAutomationTileEntity<R> extends AutomationTileEntity
     }
 
     // Business logic
+
+    abstract void consumeNonItemResources(R recipe, int parallel);
 
     // process recipes
     public void handleCrafts() {
@@ -88,6 +89,7 @@ public abstract class SimpleAutomationTileEntity<R> extends AutomationTileEntity
         // perform recipe in batch
         ItemStack output = output_instance.copy();
         output.stackSize = output.stackSize * parallel;
+        consumeNonItemResources(recipe, parallel);
 
         // commit to inventory
         inventoryHandler.setInventorySlotContents(INPUT_SIZE + OUTPUT_SIZE - 1, output);

--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedAlchemyPool.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedAlchemyPool.java
@@ -17,8 +17,10 @@ import vazkii.botania.client.core.handler.HUDHandler;
 
 public class TileAdvancedAlchemyPool extends TileAdvancedManaPool {
 
+    public static final int MANA_CAPACITY = 50000;
+
     public TileAdvancedAlchemyPool() {
-        super(Multiblocks.poolAlchemy);
+        super(Multiblocks.poolAlchemy, MANA_CAPACITY);
     }
 
     @Override
@@ -42,6 +44,6 @@ public class TileAdvancedAlchemyPool extends TileAdvancedManaPool {
     public void renderHUD(Minecraft mc, ScaledResolution res) {
         ChargeState state = ChargeState.genState(isOnline, storedMana, ACTIVATE_MANA);
         String tooltip = state.getLocalisedHudString(BHBlocks.autoPoolAlchemy);
-        HUDHandler.drawSimpleManaHUD(state.color, storedMana, MANA_CAPACITY, tooltip, res);
+        HUDHandler.drawSimpleManaHUD(state.color, storedMana, manaCapacity, tooltip, res);
     }
 }

--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedAlfPortal.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedAlfPortal.java
@@ -115,7 +115,7 @@ public class TileAdvancedAlfPortal extends SimpleAutomationTileEntity<RecipeElve
 
     @Override
     void consumeNonItemResources(RecipeElvenTrade recipe, int parallel) {
-        storedMana = storedMana - parallel * RECIPE_MANA;
+        storedMana -= parallel * RECIPE_MANA;
     }
 
     // Botania has an annoying habit of specifying multiple ingredients as ["oreDict", "oreDict", "oreDict"]

--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedAlfPortal.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedAlfPortal.java
@@ -113,6 +113,11 @@ public class TileAdvancedAlfPortal extends SimpleAutomationTileEntity<RecipeElve
         return null;
     }
 
+    @Override
+    void consumeNonItemResources(RecipeElvenTrade recipe, int parallel) {
+        storedMana = storedMana - parallel * RECIPE_MANA;
+    }
+
     // Botania has an annoying habit of specifying multiple ingredients as ["oreDict", "oreDict", "oreDict"]
     // Reduce these cases into a simple number
     //

--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedConjurationPool.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedConjurationPool.java
@@ -10,7 +10,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.recipe.RecipeManaInfusion;
@@ -18,8 +17,10 @@ import vazkii.botania.client.core.handler.HUDHandler;
 
 public class TileAdvancedConjurationPool extends TileAdvancedManaPool {
 
+    public static final int MANA_CAPACITY = 1000000;
+
     public TileAdvancedConjurationPool() {
-        super(Multiblocks.poolConjuration);
+        super(Multiblocks.poolConjuration, MANA_CAPACITY);
     }
 
     @Override
@@ -43,6 +44,6 @@ public class TileAdvancedConjurationPool extends TileAdvancedManaPool {
     public void renderHUD(Minecraft mc, ScaledResolution res) {
         ChargeState state = ChargeState.genState(isOnline, storedMana, ACTIVATE_MANA);
         String tooltip = state.getLocalisedHudString(BHBlocks.autoPoolConjuration);
-        HUDHandler.drawSimpleManaHUD(state.color, storedMana, MANA_CAPACITY, tooltip, res);
+        HUDHandler.drawSimpleManaHUD(state.color, storedMana, manaCapacity, tooltip, res);
     }
 }

--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedCraftingPool.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedCraftingPool.java
@@ -1,6 +1,5 @@
 package net.fuzzycraft.botanichorizons.addons.tileentity;
 
-import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.fuzzycraft.botanichorizons.addons.BHBlocks;
@@ -18,8 +17,10 @@ import vazkii.botania.client.core.handler.HUDHandler;
 
 public class TileAdvancedCraftingPool extends TileAdvancedManaPool {
 
+    public static final int MANA_CAPACITY = 50000;
+
     public TileAdvancedCraftingPool() {
-        super(Multiblocks.poolInfusion);
+        super(Multiblocks.poolInfusion, MANA_CAPACITY);
     }
 
     @Override
@@ -45,6 +46,6 @@ public class TileAdvancedCraftingPool extends TileAdvancedManaPool {
     public void renderHUD(Minecraft mc, ScaledResolution res) {
         ChargeState state = ChargeState.genState(isOnline, storedMana, ACTIVATE_MANA);
         String tooltip = state.getLocalisedHudString(BHBlocks.autoPoolInfusion);
-        HUDHandler.drawSimpleManaHUD(state.color, storedMana, MANA_CAPACITY, tooltip, res);
+        HUDHandler.drawSimpleManaHUD(state.color, storedMana, manaCapacity, tooltip, res);
     }
 }

--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedManaPool.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedManaPool.java
@@ -66,8 +66,7 @@ public abstract class TileAdvancedManaPool extends SimpleAutomationTileEntity<Re
 
     @Override
     void consumeNonItemResources(RecipeManaInfusion recipe, int parallel) {
-        int currentMana = storedMana;
-        storedMana = storedMana - parallel * recipe.getManaToConsume();
+        storedMana -= parallel * recipe.getManaToConsume();
     }
 
     @Override

--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedManaPool.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedManaPool.java
@@ -1,6 +1,5 @@
 package net.fuzzycraft.botanichorizons.addons.tileentity;
 
-import cpw.mods.fml.common.FMLLog;
 import net.fuzzycraft.botanichorizons.util.Facing2D;
 import net.fuzzycraft.botanichorizons.util.multiblock.MultiblockHelper;
 import net.minecraft.entity.player.EntityPlayer;
@@ -69,7 +68,6 @@ public abstract class TileAdvancedManaPool extends SimpleAutomationTileEntity<Re
     void consumeNonItemResources(RecipeManaInfusion recipe, int parallel) {
         int currentMana = storedMana;
         storedMana = storedMana - parallel * recipe.getManaToConsume();
-        FMLLog.info("Mana: %d - %d * %d = %d", currentMana, parallel, recipe.getManaToConsume(), storedMana);
     }
 
     @Override

--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedManaPool.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/tileentity/TileAdvancedManaPool.java
@@ -1,5 +1,6 @@
 package net.fuzzycraft.botanichorizons.addons.tileentity;
 
+import cpw.mods.fml.common.FMLLog;
 import net.fuzzycraft.botanichorizons.util.Facing2D;
 import net.fuzzycraft.botanichorizons.util.multiblock.MultiblockHelper;
 import net.minecraft.entity.player.EntityPlayer;
@@ -13,7 +14,7 @@ import static net.fuzzycraft.botanichorizons.util.Constants.MC_BLOCK_UPDATE;
 public abstract class TileAdvancedManaPool extends SimpleAutomationTileEntity<RecipeManaInfusion> {
 
     // Balance
-    public static final int MANA_CAPACITY = 50000;
+    public final int manaCapacity;
     public static final int CYCLE_TICKS = 20; // time between checks
     public static final int MAX_PARALLELS = 64;
     public static final int ACTIVATE_MANA = 1000;
@@ -22,8 +23,9 @@ public abstract class TileAdvancedManaPool extends SimpleAutomationTileEntity<Re
 
     // Constructors
 
-    public TileAdvancedManaPool(MultiblockHelper structure) {
+    public TileAdvancedManaPool(MultiblockHelper structure, int capacity) {
         super(structure);
+        manaCapacity = capacity;
     }
 
     // Business logic
@@ -64,6 +66,13 @@ public abstract class TileAdvancedManaPool extends SimpleAutomationTileEntity<Re
     }
 
     @Override
+    void consumeNonItemResources(RecipeManaInfusion recipe, int parallel) {
+        int currentMana = storedMana;
+        storedMana = storedMana - parallel * recipe.getManaToConsume();
+        FMLLog.info("Mana: %d - %d * %d = %d", currentMana, parallel, recipe.getManaToConsume(), storedMana);
+    }
+
+    @Override
     public int getRecipeInputStackSize(@NotNull RecipeManaInfusion recipe) {
         return 1;
     }
@@ -75,7 +84,7 @@ public abstract class TileAdvancedManaPool extends SimpleAutomationTileEntity<Re
 
     @Override
     public int getManaMaximum() {
-        return MANA_CAPACITY;
+        return manaCapacity;
     }
 
     // IWandable delegate


### PR DESCRIPTION
There were checks to make sure there was enough, but it wasn't deducted at the end.

Also bumped the conjuration fountain's buffer size so it can actually do parallels. Have fun refilling it fast enough.