### PR TITLE
fix: Bump despawn timer for tiered wrenches in line with Terra Shatterer

### DIFF
--- a/src/main/java/net/fuzzycraft/botanichorizons/addons/item/ItemSuperchargedWrench.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/addons/item/ItemSuperchargedWrench.java
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
+import net.minecraft.world.World;
 import vazkii.botania.api.mana.IManaGivingItem;
 import vazkii.botania.api.mana.IManaItem;
 import vazkii.botania.api.mana.IManaTooltipDisplay;
@@ -101,6 +102,11 @@ public abstract class ItemSuperchargedWrench extends ItemManaWrench implements I
     @Override
     public boolean isNoExport(ItemStack stack) {
         return true;
+    }
+
+    @Override
+    public int getEntityLifespan(ItemStack itemStack, World world) {
+        return Integer.MAX_VALUE;
     }
 
     // IManaTooltipDisplay


### PR DESCRIPTION
Currently tierable wrenches can despawn while in item form, which is different from the similar Terra Shatterer and makes it harder to upgrade by having to check item once in a while.
Tested with dropped Erosion and Evolution wrenches alongside with a normal item, normal item despawned earlier while wrenches stayed.

Related Terra Shatterer code: https://github.com/GTNewHorizons/Botania/blob/master/src/main/java/vazkii/botania/common/item/equipment/tool/terrasteel/ItemTerraPick.java#L183C2-L187C1

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22654