### PR TITLE
Fixes NoSuchMethodError gregtech.api.interfaces.IIconContainer.getIcon with fancy wrench

### DIFF
--- a/src/main/java/net/fuzzycraft/botanichorizons/util/structurelib/HoloExtractor.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/util/structurelib/HoloExtractor.java
@@ -92,7 +92,7 @@ public class HoloExtractor {
                 return null;
             }
             return scanner;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             FMLLog.log(Level.WARN, e, "Scanning for hologram failed: %s at %d, %d, %d",
                     tileEntity.getClass().getName(),
                     tileEntity.xCoord,

--- a/src/main/java/net/fuzzycraft/botanichorizons/util/structurelib/HoloScanner.java
+++ b/src/main/java/net/fuzzycraft/botanichorizons/util/structurelib/HoloScanner.java
@@ -23,7 +23,7 @@ public class HoloScanner {
 
         // This API stinks, send events to OnStructureEvent though a callback located in ThreadLocalStorage
         ItemStack buildStack = new ItemStack(StructureLibAPI.getDefaultHologramItem());
-        constructable.construct(buildStack, true);
+        constructable.construct(buildStack, false);
 
         StructureLibAPI.disableInstrument();
         MinecraftForge.EVENT_BUS.unregister(this);


### PR DESCRIPTION
Using the Disassembly Wrench on any multiblock whose structure definition uses ofFrame() (39 GT5 multiblocks including Neutronium Compressor, Tesla Tower, Nano Forge, etc.) crashes the dedicated server with NoSuchMethodError because the hologram scanner ran in hint mode, which calls IIconContainer.getIcon() a @SideOnly(Side.CLIENT) method stripped from the server JAR.

The crash : 
[crash-2026-02-11_08.01.02-server.txt](https://github.com/user-attachments/files/25228716/crash-2026-02-11_08.01.02-server.txt)

The pr fixes the issue.